### PR TITLE
update UG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -681,4 +681,11 @@ have careers with variable income.
    - Additionally, right now the income field does not accept a value of 0. This is not inclusive towards students 
 who may not have any income. Hence, we plan to modify the field to accept a value of 0, on top of supporting a range 
 of values
+
+2. Improve issues regarding sorting stability
+   - Currently you are able to sort the dates by a specific field. However, if we sort by income for instance, and two
+dates have the same value, then when one of those two dates are modified by operations such as star or edit, the order 
+of the two of them can change. The dates are still sorted in order, just that the stability is disrupted. We intend
+to improve upon our star and edit commands such that they do not disrupt the stability in the future.
+
 ------------------------------------------------------------

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -95,7 +95,7 @@ online dating journey.
 * `AGE` should be a positive integer between 18 and 150 (inclusive).
 * `GENDER` should be either M or F. It is case sensitive.
 * `HOROSCOPE` should be a valid zodiac sign. It is case insensitive.
-* `INCOME` (per month) should be a positive integer in SGD.
+* `INCOME` (per month) should be a positive integer in SGD less than or equal to a million.
 * `HEIGHT` should be a positive integer in cm between 100cm and 250cm (inclusive).
 
 </box>

--- a/src/main/java/seedu/lovebook/model/date/Income.java
+++ b/src/main/java/seedu/lovebook/model/date/Income.java
@@ -17,7 +17,7 @@ public class Income implements Comparable<Income> {
      * The first character of the LoveBook must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^(0|[1-9]\\d{0,5}|1000000)$";
+    public static final String VALIDATION_REGEX = "^([1-9]\\d{0,5}|[1-9]\\d{0,5}|1000000)$";
 
     public final String value;
 


### PR DESCRIPTION
I modified the regex such that income does not accept a 0 value. This is because previously i modified the regex to accept a 0 value in response to the bug reports from the dry run. This was a violation of the feature freeze so i undid it here. However, I chose to keep the newly modified limit to a million after the dry run because if a user were to key in excess income values, then it would throw a numberFormat exception for the bestMatch command causing it to freeze. This thus causes a difference in behaviour between actual and advertised. Hence that is a valid change